### PR TITLE
Set CURLOPT_SSL_VERIFYHOST to false to disable errors on host name mi…

### DIFF
--- a/lib/POE/Component/Curl/Multi.pm
+++ b/lib/POE/Component/Curl/Multi.pm
@@ -202,6 +202,7 @@ sub _request {
     my $req = $args->{request};
     $easy->setopt(CURLOPT_URL, $req->uri);
     $easy->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+    $easy->setopt(CURLOPT_SSL_VERIFYHOST, 0);
     $easy->setopt(CURLOPT_DNS_CACHE_TIMEOUT, 0);
     $easy->setopt(CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     $easy->setopt(CURLOPT_ENCODING, '');


### PR DESCRIPTION
…smatch with SSL certificates.

It would be better if SSL_VERIFYPEER, SSL_VERIFYHOST, and other cURL lib options, were configurable when the component gets spawned.
